### PR TITLE
Load libraries for byte-compile warnings

### DIFF
--- a/zettel-mode.el
+++ b/zettel-mode.el
@@ -29,6 +29,8 @@
 
 (require 'cl-lib)
 (require 'deft)
+(require 'subr-x)
+(require 'org)
 
 (defgroup zettel-mode nil
   "A mode for Zettelkasten-style note-taking."


### PR DESCRIPTION
```
In zettel--insert-external-refs:
zettel-mode.el:163:38:Warning: ‘(links (zettel--get-external-refs
    target-file))’ is a malformed function

In zettel-sidebar-mode:
zettel-mode.el:304:15:Warning: assignment to free variable
    ‘org-return-follows-link’
zettel-mode.el:305:46:Warning: assignment to free variable
    ‘org-cycle-include-plain-lists’

In end of data:
zettel-mode.el:310:1:Warning: the following functions are not known to be defined:
    org-element-map, org-element-parse-buffer, org-element-property,
    org-export-get-environment, org-element-contents,
    org-insert-link, when-let, org-next-link, org-previous-link
```